### PR TITLE
корректируем цитаты при конвертации, пустые цитаты удаляем

### DIFF
--- a/api/perl/FB3-Convert/lib/FB3/Convert.pm
+++ b/api/perl/FB3-Convert/lib/FB3/Convert.pm
@@ -21,7 +21,7 @@ use XML::Entities::Data;
 use Time::HiRes qw(gettimeofday sleep);
 binmode(STDOUT,':utf8');
 
-our $VERSION = 0.13;
+our $VERSION = 0.14;
 
 =head1 NAME
 

--- a/api/perl/FB3-Convert/lib/FB3/Convert.pm
+++ b/api/perl/FB3-Convert/lib/FB3/Convert.pm
@@ -21,7 +21,7 @@ use XML::Entities::Data;
 use Time::HiRes qw(gettimeofday sleep);
 binmode(STDOUT,':utf8');
 
-our $VERSION = 0.14;
+our $VERSION = 0.15;
 
 =head1 NAME
 


### PR DESCRIPTION
переносим содержимое заголовков цитат в тело цитаты, если кроме заголовков в цитате ничего нет. пустые цитаты удаляем
