### PR TITLE
`QXcbConnection: Could not connect to display' fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#FB3: FictionBook v. 3
+# FB3: FictionBook v. 3
 
 Open eBook format, epub replacement/addition (depends on how you use it). In this repositore you can find format
 schema and conversion tools
 
-##See also
+## See also
 
 FB3Editor: https://github.com/Litres/FB3Editor
 

--- a/api/perl/FB3-Convert/lib/FB3/Convert.pm
+++ b/api/perl/FB3-Convert/lib/FB3/Convert.pm
@@ -21,7 +21,7 @@ use XML::Entities::Data;
 use Time::HiRes qw(gettimeofday sleep);
 binmode(STDOUT,':utf8');
 
-our $VERSION = 0.16;
+our $VERSION = 0.17;
 
 =head1 NAME
 

--- a/api/perl/FB3-Convert/t/test1.t
+++ b/api/perl/FB3-Convert/t/test1.t
@@ -82,16 +82,17 @@ ok(1,'Test ok');
 exit;
 
 sub PhantomIsSupport {
+
   my $Supp = FindFile('phantomjs', [split /:/,$ENV{'PATH'}]);
 
   if ($Supp) {
     diag('phantomjs founded ['.$Supp.']. Euristic enabled');
-  } else {
-    diag('phantomjs not found. Euristic skipped. see <http://phantomjs.org/>');
-		return;
+    $ENV{'QT_QPA_PLATFORM'} = 'offscreen'; # NOTE to avoid `QXcbConnection: Could not connect to display' error
+    return 1;
   }
 
-  return 1;
+  diag('phantomjs not found. Euristic skipped. see <http://phantomjs.org/>');
+  return 0;
 }
 
 sub FindFile {


### PR DESCRIPTION
исправляем ситуацию с тестом phantomjs
```
Output from './Build test':

# Testing FB3::Convert 0.16, Perl 5.026002, /opt/perl-5.26.2-RC1/bin/perl
t/00-load.t .. ok
# Testing result of body.xml, Perl 5.026002, /opt/perl-5.26.2-RC1/bin/perl
# phantomjs founded [/usr/bin/phantomjs]. Euristic enabled
# Testing t/examples/xss_108909.epub and compare with t/examples/xss_108909.xml
# Testing t/examples/trim_split_empty_p_108909.epub and compare with t/examples/trim_split_empty_p_108909.xml
# Testing t/examples/simple_108909.epub and compare with t/examples/simple_108909.xml
# Testing t/examples/title_in_section_108909.epub and compare with t/examples/title_in_section_108909.xml
# Testing t/examples/move_empty_a_109373.epub and compare with t/examples/move_empty_a_109373.xml
# Testing t/examples/empty_a_near_h_109373.epub and compare with t/examples/empty_a_near_h_109373.xml
# Testing t/examples/empty_p_near_h_109373.epub and compare with t/examples/empty_p_near_h_109373.xml
# Testing t/examples/rm_unlink_id_a_span_109373.epub and compare with t/examples/rm_unlink_id_a_span_109373.xml
# Testing t/examples/euristica_ok_109381.epub and compare with t/examples/euristica_ok_109381.xml
QXcbConnection: Could not connect to display 
PhantomJS has crashed. Please read the bug reporting guide at
<http://phantomjs.org/bug-reporting.html> and file a bug report.
Selenium server did not return proper status at /opt/perl-5.26.2-RC1/lib/site_perl/5.26.2/Selenium/Remote/Driver.pm line 487.
# Looks like your test exited with 111 before it could output anything.
t/test1.t .... 
Dubious, test returned 111 (wstat 28416, 0x6f00)
Failed 1/1 subtests 
```