### PR TITLE
здесь нам всегда нужен скалярный контекст

### DIFF
--- a/api/perl/OPC/lib/OPC.pm
+++ b/api/perl/OPC/lib/OPC.pm
@@ -160,7 +160,7 @@ sub GetPhysicalContents {
   my $IsBinary = exists $Param{binary} ? $Param{binary} : 0;
   
 	if( $self->{_is_zip} ) {
-		return $self->{_physical}->contents( $PhysicalName );
+		return scalar $self->{_physical}->contents( $PhysicalName );
 	} else {
 		return do {
       my $Layer = $IsBinary ? 'raw' : 'encoding(UTF-8)';


### PR DESCRIPTION
иначе, в списочном контексте, возвращается содержимое **и статус**